### PR TITLE
feat: implement GSI definitions in db schema

### DIFF
--- a/dev/releases/011_dbapi.md
+++ b/dev/releases/011_dbapi.md
@@ -6,6 +6,10 @@ release documentation `docs/releases/011_dbapi.md`
 
 session logs are timestamped to Singapore timezone in reverse chronological order, with latest entries at the top, and earlier entries at the bottom.
 
+### GSI [Codex] 2025-08-12 16:37:07
+- reviewed `docs/data_model.md` and removed outdated sort key for `post_details`
+- expanded `storage/db_schema.json` with table schemas and declared GSI per data model
+
 ### GSI [Data Engineer] Codex prompt 2025-08-12 16:31
 
 __situation__

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -112,14 +112,13 @@ __Global Secondary Indexes__
 ### Table: post_details
 
 - Primary Key: `post_id`
-- Sort Key: `closing_date`
 
 | Column Name      | Data Type | Nullable | Description                    |
 |------------------|-----------|----------|--------------------------------|
 | post_id           | String    | No       | Foreign key to post table     |
 | description      | String    | Yes      | long text description about the job and requirements |
 | url_slug         | String    | Yes      | primary MCF UID reference from url |
-| mcf_ref          | String    | Yes      | secondary MCF reference taken from card and or post|
+| mcf_ref          | String    | Yes      | secondary MCF reference taken from card and or post |
 
 __Global Secondary Indexes__
 

--- a/storage/db_schema.json
+++ b/storage/db_schema.json
@@ -1,60 +1,153 @@
 {
   "tables": [
     {
-      "table_name": "apply_status",
-      "primary_key": "job_id",
+      "table_name": "post",
+      "primary_key": "id",
+      "sort_key": "posted_date",
       "columns": [
-        {
-          "column_name": "job_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "status",
-          "data_type": "Number",
-          "nullable": false
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
+        { "column_name": "id", "data_type": "String", "nullable": false },
+        { "column_name": "post_source_id", "data_type": "String", "nullable": false },
+        { "column_name": "position", "data_type": "String", "nullable": false },
+        { "column_name": "company_name", "data_type": "String", "nullable": true },
+        { "column_name": "posted_date", "data_type": "String", "nullable": false },
+        { "column_name": "url", "data_type": "String", "nullable": true },
+        { "column_name": "closing_date", "data_type": "String", "nullable": true },
+        { "column_name": "salary_high_sgd", "data_type": "Number", "nullable": true },
+        { "column_name": "status", "data_type": "Number", "nullable": false },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
+      ],
+      "secondary_indexes": {
+        "global": [
+          {
+            "partition_key": "status",
+            "sort_key": "posted_date",
+            "projection": "ALL"
+          }
+        ]
+      }
+    },
+    {
+      "table_name": "post_details",
+      "primary_key": "post_id",
+      "columns": [
+        { "column_name": "post_id", "data_type": "String", "nullable": false },
+        { "column_name": "description", "data_type": "String", "nullable": true },
+        { "column_name": "url_slug", "data_type": "String", "nullable": true },
+        { "column_name": "mcf_ref", "data_type": "String", "nullable": true },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
+      ],
+      "secondary_indexes": {
+        "global": [
+          {
+            "partition_key": "url_slug",
+            "sort_key": "post_id",
+            "projection": { "type": "KEYS_ONLY" }
+          }
+        ]
+      }
+    },
+    {
+      "table_name": "post_source",
+      "primary_key": "id",
+      "columns": [
+        { "column_name": "id", "data_type": "Number", "nullable": false },
+        { "column_name": "name", "data_type": "String", "nullable": false },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
       ]
     },
     {
-      "table_name": "crm_status",
-      "primary_key": "job_id",
+      "table_name": "user",
+      "primary_key": "id",
       "columns": [
-        {
-          "column_name": "job_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "status",
-          "data_type": "Number",
-          "nullable": false
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
+        { "column_name": "id", "data_type": "String", "nullable": false },
+        { "column_name": "email", "data_type": "String", "nullable": false },
+        { "column_name": "username", "data_type": "String", "nullable": false },
+        { "column_name": "name", "data_type": "String", "nullable": true },
+        { "column_name": "deactivated_date", "data_type": "String", "nullable": true },
+        { "column_name": "status", "data_type": "Number", "nullable": false },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
+      ],
+      "secondary_indexes": {
+        "global": [
+          { "partition_key": "email", "projection": { "type": "KEYS_ONLY" } },
+          { "partition_key": "username", "projection": { "type": "KEYS_ONLY" } },
+          { "partition_key": "status", "projection": "ALL" }
+        ]
+      }
+    },
+    {
+      "table_name": "user_config",
+      "primary_key": "user_id",
+      "columns": [
+        { "column_name": "user_id", "data_type": "String", "nullable": false },
+        { "column_name": "email_notifications", "data_type": "Boolean", "nullable": true },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
       ]
+    },
+    {
+      "table_name": "role",
+      "primary_key": "id",
+      "columns": [
+        { "column_name": "id", "data_type": "String", "nullable": false },
+        { "column_name": "role_name", "data_type": "String", "nullable": false },
+        { "column_name": "description", "data_type": "String", "nullable": true },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
+      ]
+    },
+    {
+      "table_name": "track",
+      "primary_key": "id",
+      "sort_key": "user_id",
+      "columns": [
+        { "column_name": "id", "data_type": "String", "nullable": false },
+        { "column_name": "user_id", "data_type": "String", "nullable": false },
+        { "column_name": "role_id", "data_type": "String", "nullable": false },
+        { "column_name": "seniority", "data_type": "Number", "nullable": true },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
+      ],
+      "secondary_indexes": {
+        "global": [
+          { "partition_key": "user_id", "projection": "ALL" }
+        ]
+      }
+    },
+    {
+      "table_name": "search_profile",
+      "primary_key": "track_id",
+      "columns": [
+        { "column_name": "track_id", "data_type": "String", "nullable": false },
+        { "column_name": "keywords", "data_type": "String", "nullable": true },
+        { "column_name": "salary_target_sgd", "data_type": "Number", "nullable": true },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
+      ]
+    },
+    {
+      "table_name": "job_track",
+      "primary_key": "id",
+      "sort_key": "track_id",
+      "columns": [
+        { "column_name": "id", "data_type": "String", "nullable": false },
+        { "column_name": "job_id", "data_type": "String", "nullable": false },
+        { "column_name": "track_id", "data_type": "String", "nullable": false },
+        { "column_name": "search_match", "data_type": "Boolean", "nullable": true },
+        { "column_name": "assigned", "data_type": "Boolean", "nullable": true },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
+      ],
+      "secondary_indexes": {
+        "global": [
+          { "partition_key": "job_id", "sort_key": "track_id", "projection": "ALL" },
+          { "partition_key": "track_id", "sort_key": "job_id", "projection": "ALL" }
+        ]
+      }
     },
     {
       "table_name": "job",
@@ -69,458 +162,71 @@
         { "column_name": "posted_date", "data_type": "String", "nullable": false },
         { "column_name": "closing_date", "data_type": "String", "nullable": false },
         { "column_name": "company_name", "data_type": "String", "nullable": true },
-        { "column_name": "salary_high_sgd", "data_type": "Number", "nullable": true },
         { "column_name": "url", "data_type": "String", "nullable": true },
+        { "column_name": "salary_high_sgd", "data_type": "Number", "nullable": true },
         { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
         { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
-      ]
+      ],
+      "secondary_indexes": {
+        "global": [
+          { "partition_key": "user_id", "sort_key": "id", "projection": { "type": "INCLUDE", "attributes": ["post_id", "position", "company_name", "posted_date", "url"] } },
+          { "partition_key": "post_id", "sort_key": "id", "projection": { "type": "KEYS_ONLY" } },
+          { "partition_key": "user_id", "sort_key": "company_name", "projection": { "type": "KEYS_ONLY" } },
+          { "partition_key": "user_id", "sort_key": "position", "projection": { "type": "KEYS_ONLY" } }
+        ]
+      }
     },
     {
       "table_name": "job_details",
       "primary_key": "job_id",
       "columns": [
-        {
-          "column_name": "job_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "position",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "company_name",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
-      ]
-    },
-    {
-      "table_name": "job_track",
-      "primary_key": "id",
-      "sort_key": "track_id",
-      "columns": [
-        {
-          "column_name": "id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "track_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "job_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "search_match",
-          "data_type": "Boolean",
-          "nullable": true
-        },
-        {
-          "column_name": "assigned",
-          "data_type": "Boolean",
-          "nullable": true
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
-      ]
-    },
-    {
-      "table_name": "post",
-      "primary_key": "id",
-      "sort_key": "posted_date",
-      "columns": [
-        {
-          "column_name": "id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "posted_date",
-          "data_type": "String",
-          "date_format": "ISO_DATE",
-          "nullable": false
-        },
-        {
-          "column_name": "position",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "company_name",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "url",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "status",
-          "data_type": "Number",
-          "nullable": false
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
-      ]
-    },
-    {
-      "table_name": "post_details",
-      "primary_key": "post_id",
-      "sort_key": "closing_date",
-      "columns": [
-        {
-          "column_name": "post_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "closing_date",
-          "data_type": "String",
-          "date_format": "ISO_DATE",
-          "nullable": false
-        },
-        {
-          "column_name": "post_source_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "salary_high_sgd",
-          "data_type": "Number",
-          "nullable": true
-        },
-        {
-          "column_name": "url_slug",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "mcf_ref",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
-      ]
-    },
-    {
-      "table_name": "post_source",
-      "primary_key": "id",
-      "columns": [
-        {
-          "column_name": "id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "name",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
-      ]
-    },
-    {
-      "table_name": "role",
-      "primary_key": "id",
-      "columns": [
-        {
-          "column_name": "id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "role_name",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "description",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
-      ]
-    },
-    {
-      "table_name": "search_profile",
-      "primary_key": "track_id",
-      "columns": [
-        {
-          "column_name": "track_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "keywords",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "salary_target_sgd",
-          "data_type": "Number",
-          "nullable": true
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
-      ]
-    },
-    {
-      "table_name": "track",
-      "primary_key": "id",
-      "sort_key": "user_id",
-      "columns": [
-        {
-          "column_name": "id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "user_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "role_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "seniority",
-          "data_type": "Number",
-          "nullable": true
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
-      ]
-    },
-    {
-      "table_name": "track_cv",
-      "primary_key": "track_id",
-      "columns": [
-        {
-          "column_name": "track_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "cv_code",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
+        { "column_name": "job_id", "data_type": "String", "nullable": false },
+        { "column_name": "update", "data_type": "String", "nullable": true },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
       ]
     },
     {
       "table_name": "track_score",
       "primary_key": "job_track_id",
       "columns": [
-        {
-          "column_name": "job_track_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "score",
-          "data_type": "Number",
-          "nullable": false
-        },
-        {
-          "column_name": "method",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
+        { "column_name": "job_track_id", "data_type": "String", "nullable": false },
+        { "column_name": "score", "data_type": "Number", "nullable": false },
+        { "column_name": "method", "data_type": "String", "nullable": false },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
       ]
     },
     {
-      "table_name": "user",
-      "primary_key": "id",
+      "table_name": "track_cv",
+      "primary_key": "track_id",
       "columns": [
-        {
-          "column_name": "id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "email",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "username",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "name",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "deactivated_date",
-          "data_type": "String",
-          "nullable": true
-        },
-        {
-          "column_name": "status",
-          "data_type": "Number",
-          "nullable": false
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
+        { "column_name": "track_id", "data_type": "String", "nullable": false },
+        { "column_name": "cv_code", "data_type": "String", "nullable": false },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
       ]
     },
     {
-      "table_name": "user_config",
-      "primary_key": "user_id",
+      "table_name": "crm_status",
+      "primary_key": "job_id",
       "columns": [
-        {
-          "column_name": "user_id",
-          "data_type": "String",
-          "nullable": false
-        },
-        {
-          "column_name": "email_notifications",
-          "data_type": "Boolean",
-          "nullable": true
-        },
-        {
-          "column_name": "created",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        },
-        {
-          "column_name": "last_modified",
-          "data_type": "String",
-          "date_format": "ISO_TIMESTAMP",
-          "nullable": false
-        }
+        { "column_name": "job_id", "data_type": "String", "nullable": false },
+        { "column_name": "status", "data_type": "Number", "nullable": false },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
+      ]
+    },
+    {
+      "table_name": "apply_status",
+      "primary_key": "job_id",
+      "columns": [
+        { "column_name": "job_id", "data_type": "String", "nullable": false },
+        { "column_name": "status", "data_type": "Number", "nullable": false },
+        { "column_name": "created", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false },
+        { "column_name": "last_modified", "data_type": "String", "date_format": "ISO_TIMESTAMP", "nullable": false }
       ]
     }
   ]
 }
+


### PR DESCRIPTION
## Summary
- remove obsolete sort key from post_details in data model
- expand db schema with table specs and global secondary indexes

## Testing
- `python -m json.tool storage/db_schema.json`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689afc08bdec8323b1fe58bf00f35dbf